### PR TITLE
Refactor Docker setup, update WebSocket service for improved connection handling and message queuing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM node:16-alpine as frontend
-WORKDIR /app/frontend
-COPY frontend/package*.json ./
+FROM node:16-alpine
+WORKDIR /app
+COPY package*.json ./
 RUN npm install
-COPY frontend/ ./
-RUN npm run build
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]
 
 FROM python:3.9-slim
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   web:
     build: .
     ports:
-      - "8000:8000"
+      - "3000:3000"
     volumes:
       - .:/app
     depends_on:
@@ -14,6 +14,7 @@ services:
       - DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
       - DATABASE_URL=postgres://postgres:postgres@db:5432/chatify
       - REDIS_URL=redis://redis:6379
+      - NODE_ENV=development
 
   db:
     image: postgres:13

--- a/frontend/src/services/websocket.js
+++ b/frontend/src/services/websocket.js
@@ -3,14 +3,26 @@ class WebSocketService {
         this.socket = null;
         this.reconnectAttempts = 0;
         this.MAX_RECONNECT_ATTEMPTS = 5;
+        this.listeners = new Map();
+        this.connectionState = 'disconnected';
+        this.messageQueue = [];
+        this.debug = false;
+    }
+
+    get isConnected() {
+        return this.connectionState === 'connected';
     }
 
     connect(url) {
+        this.currentUrl = url;
+        this.connectionState = 'connecting';
         return new Promise((resolve, reject) => {
             this.socket = new WebSocket(url);
 
             this.socket.onopen = () => {
                 this.reconnectAttempts = 0;
+                this.connectionState = 'connected';
+                this.processPendingMessages();
                 resolve();
             };
 
@@ -22,18 +34,56 @@ class WebSocketService {
     handleDisconnect() {
         if (this.reconnectAttempts < this.MAX_RECONNECT_ATTEMPTS) {
             this.reconnectAttempts++;
-            setTimeout(() => this.connect, 1000 * this.reconnectAttempts);
+            const backoffTime = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 10000);
+            console.log(`Attempting to reconnect in ${backoffTime / 1000} seconds...`);
+            setTimeout(() => this.connect(this.currentUrl), backoffTime);
+        } else {
+            console.error('Max reconnection attempts reached');
+            this.emit('maxReconnectAttemptsReached');
         }
     }
 
     sendMessage(message) {
         if (this.socket?.readyState === WebSocket.OPEN) {
             this.socket.send(JSON.stringify(message));
+        } else {
+            this.messageQueue.push(message);
+            console.log('Message queued for later sending');
+        }
+    }
+
+    processPendingMessages() {
+        while (this.messageQueue.length > 0 && this.socket?.readyState === WebSocket.OPEN) {
+            const message = this.messageQueue.shift();
+            this.sendMessage(message);
         }
     }
 
     disconnect() {
         this.socket?.close();
+    }
+
+    addEventListener(event, callback) {
+        if (!this.listeners.has(event)) {
+            this.listeners.set(event, new Set());
+        }
+        this.listeners.get(event).add(callback);
+    }
+
+    removeEventListener(event, callback) {
+        if (this.listeners.has(event)) {
+            this.listeners.get(event).delete(callback);
+        }
+    }
+
+    log(...args) {
+        if (this.debug) {
+            console.log('[WebSocketService]', ...args);
+        }
+    }
+
+    setDebug(enabled) {
+        this.debug = enabled;
     }
 }
 


### PR DESCRIPTION
This pull request includes significant updates to the Docker configuration and enhancements to the WebSocket service in the frontend. The most important changes are detailed below:

### Docker configuration updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R7): Simplified the Dockerfile by consolidating the frontend and backend setup steps, exposing port 3000, and setting the default command to start the application.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L6-R6): Updated the web service to use port 3000 instead of 8000 and added the `NODE_ENV` environment variable set to `development`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L6-R6) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R17)

### WebSocket service enhancements:

* [`frontend/src/services/websocket.js`](diffhunk://#diff-8144ac8ead30c91c2d269e232bcba7cf8313186f08b0dad5130a8b2b0ff44a04R6-R25): Added new properties and methods to the `WebSocketService` class, including `listeners`, `connectionState`, `messageQueue`, `debug`, `isConnected`, `processPendingMessages`, `addEventListener`, `removeEventListener`, `log`, and `setDebug`. Improved the `connect`, `handleDisconnect`, and `sendMessage` methods to handle connection state and message queuing more effectively. [[1]](diffhunk://#diff-8144ac8ead30c91c2d269e232bcba7cf8313186f08b0dad5130a8b2b0ff44a04R6-R25) [[2]](diffhunk://#diff-8144ac8ead30c91c2d269e232bcba7cf8313186f08b0dad5130a8b2b0ff44a04L25-R87)