### PR TITLE
Update .gitignore to include .vscode and add DjangoChatify.session.sql for database table display query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .env
 .vscode
+.vscode/settings.json

--- a/DjangoChatify.session.sql
+++ b/DjangoChatify.session.sql
@@ -1,0 +1,10 @@
+-- Display all tables in the current database
+SELECT table_schema,
+    table_name
+FROM information_schema.tables
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+    AND table_type = 'BASE TABLE'
+ORDER BY table_schema,
+    table_name;
+-- Alternatively, for a simpler view, you can use:
+-- \dt  -- This works in psql CLI but not in SQLTools


### PR DESCRIPTION
This pull request includes a new SQL script to display all tables in the current database. The script retrieves table schemas and names from the `information_schema.tables` and excludes system tables.

Database query addition:

* [`DjangoChatify.session.sql`](diffhunk://#diff-c044d04b26575d795e06e262344278415249edab8eda9c10c9c40c3b5dc1b5ceR1-R10): Added a query to list all tables in the current database, excluding system tables, and provided an alternative command for use in the psql CLI.