### PR TITLE
Add test database configuration to settings.py

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -104,6 +104,9 @@ else:
             'PASSWORD': os.getenv('DB_PASSWORD'),
             'HOST': os.getenv('DB_HOST'),
             'PORT': os.getenv('DB_PORT'),
+            'TEST': {
+                'NAME': 'test_' + os.getenv('DB_NAME', 'djangochatify_db'),
+            },
         }
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `backend/settings.py` file. The change adds a configuration for the test database name, which appends 'test_' to the existing database name.

* [`backend/settings.py`](diffhunk://#diff-fe7571263349dbdde0f862e23493c69176f52a97e56402233fa571755f50bf2aR107-R109): Added a `TEST` configuration to the database settings to specify the test database name.