### PR TITLE
Remove redundant code quality and security checks from CI workflow

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -74,19 +74,6 @@ jobs:
         run: |
           python manage.py migrate --verbosity=0
 
-      - name: Check code formatting with black
-        run: |
-          black --check --quiet .
-
-      - name: Run flake8 for linting
-        run: |
-          flake8 . --count --select=E9,F63,F7,F82
-
-      - name: Run type checking with mypy
-        run: |
-          mypy . --no-error-summary
-        continue-on-error: true
-
       - name: Django system check
         run: |
           python manage.py check --verbosity=0
@@ -97,35 +84,9 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: backend.settings
 
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip --quiet
-          pip install safety bandit --quiet
-
-      - name: Run security checks with safety
-        run: |
-          safety check --short-report
-        continue-on-error: true
-
-      - name: Run security checks with bandit
-        run: |
-          bandit -r . --quiet
-        continue-on-error: true
-
   build:
     runs-on: ubuntu-latest
-    needs: [test, security]
+    needs: [test]
     if: github.ref == 'refs/heads/main'
 
     steps:


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflow for the Django project by removing redundant or non-critical steps. The most significant changes involve the removal of code formatting, linting, type checking, and security checks.

### Workflow Simplification:

* Removed steps for code formatting checks using `black`, linting with `flake8`, and type checking with `mypy` from the `test` job in `.github/workflows/django.yml`. These steps were deemed unnecessary or redundant.

* Deleted the entire `security` job, which included security checks using `safety` and `bandit`. This also removed the dependency of the `build` job on the `security` job. The `build` job now only depends on the `test` job.